### PR TITLE
isAccessScopesRequest(string $uri) added

### DIFF
--- a/src/OhMyBrew/BasicShopifyAPI.php
+++ b/src/OhMyBrew/BasicShopifyAPI.php
@@ -884,6 +884,18 @@ class BasicShopifyAPI
     {
         return strpos($uri, '/admin/oauth/authorize') === false && strpos($uri, '/admin/oauth/access_token') === false;
     }
+    
+    /**
+     * Determines if the request endpoint is /admin/oauth/access_scopes.json
+     *
+     * @param string $uri
+     *
+     * @return bool
+     */
+    protected function isAccessScopesRequest(string $uri)
+    {
+        return strpos($uri, '/admin/oauth/access_scopes.json') !== false;
+    }
 
     /**
      * Versions the API call with the set version.
@@ -894,7 +906,7 @@ class BasicShopifyAPI
      */
     protected function versionPath(string $uri)
     {
-        if ($this->version === null || preg_match(self::VERSION_PATTERN, $uri) || !$this->isAuthableRequest($uri)) {
+        if ($this->version === null || preg_match(self::VERSION_PATTERN, $uri) || $this->isAccessScopesRequest($uri)) {
             // No version set, or already versioned... nothing to do
             return $uri;
         }


### PR DESCRIPTION
`Line 909` function added to check if this request is to `/admin/oauth/access_scopes.json`, if so `return` without adding version.

FYI:
`$this->isAuthableRequest($uri)` will not work as expected, because it is checking for `authorize` and`access_token`, which donot need oauth.
While, /admin/oauth/access_scopes.json needs oauth.

So, `$this-> isAuthableRequest('/admin/oauth/access_scopes.json')` will return `true` which is perfect, but in `Line 909` return `true` will not allow execution of `Line 911`, hence $uri from `versionPath()` will be returned with version added. 
Will cause 404 error, when endpoint is `/admin/oauth/access_scopes.json`


