### PR TITLE
Added status field to successful rest() responses

### DIFF
--- a/src/OhMyBrew/BasicShopifyAPI.php
+++ b/src/OhMyBrew/BasicShopifyAPI.php
@@ -760,6 +760,7 @@ class BasicShopifyAPI implements LoggerAwareInterface
             // Return Guzzle response and JSON-decoded body
             return (object) [
                 'errors'     => false,
+                'status'     => $status,
                 'response'   => $resp,
                 'body'       => $this->jsonDecode($body),
                 'link'       => $link,


### PR DESCRIPTION
It seems simpler to be able to assume that the HTTP status code is always available from the rest() object instead of having to dive into the response to get it.

It's a 1-line change, and passes testing as it is.

Thank you.